### PR TITLE
Docker image for Memcached service

### DIFF
--- a/memcached/Dockerfile
+++ b/memcached/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:14.04
+
+MAINTAINER Andrea Grandi <andrea@thisisglow.com>
+
+# Install RabbitMQ
+RUN apt-get update -y && apt-get install -y memcached
+
+# Add memuser user to run the service with
+RUN groupadd -g 1001 memuser
+RUN useradd -m -s /bin/bash -u 1001 -g 1001 memuser
+
+# Expose the Memcached default port
+EXPOSE 11211
+
+# Entry point to run memcached in foreground
+CMD ["memcached", "-u", "memuser"]

--- a/memcached/README.md
+++ b/memcached/README.md
@@ -1,0 +1,7 @@
+To rebuild the image:
+
+    docker build --force-rm=true --rm=true --tag="glow/memcached:latest" .
+
+To run the service:
+
+    fig up


### PR DESCRIPTION
This Dockerfile allows the creation of an image to run a Memcached container.

TP task https://thisisglow.tpondemand.com/entity/3876
