### PR TITLE
Add new base image

### DIFF
--- a/glowbase/Dockerfile
+++ b/glowbase/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:14.04
+
+MAINTAINER Andrea Grandi <andrea@thisisglow.com>
+
+RUN apt-get update -y && \
+apt-get install -y python-dev build-essential python-pip libcurl4-gnutls-dev python2.7-dev libpq-dev supervisor nfs-common git nginx libjpeg-dev npm nodejs-legacy python-dev build-essential python-pip python2.7-dev wget unzip openjdk-6-jre git ruby nginx && \
+apt-get clean && \
+rm -rf /var/lib/apt/lists/* && \
+groupadd -g 1001 glowconsole && \
+useradd -m -s /bin/bash -u 1001 -g 1001 glowconsole

--- a/glowbase/README.md
+++ b/glowbase/README.md
@@ -1,0 +1,10 @@
+This is the common base image for the backend and frontend containers.
+
+
+To rebuild the image:
+
+    docker build --force-rm=true --rm=true --tag="glow/memcached:latest" .
+
+To run the service:
+
+    fig up

--- a/glowbase/README.md
+++ b/glowbase/README.md
@@ -8,3 +8,8 @@ To rebuild the image:
 To run the service:
 
     fig up
+
+
+To push the image:
+
+    docker push glow/glowbase:latest


### PR DESCRIPTION
Using a base image like this will mean that we don't redo `apt-get update` every time we want to build a branch, speeding up the build.

I have included all the apt stuff for the backend and the ui into one image which can be reused. I've tested using QA2 and will make PRs for the backend and ui v soon.

@andreagrandi Looks ok?
